### PR TITLE
chore: update repo urls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Mason L'Etoile
+Copyright (c) 2025 Starlet Libraries, Mason L'Etoile
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A lightweight graphics loading &amp; management library for Starlet projects wit
 include(FetchContent)
 
 FetchContent_Declare(starlet_graphics
-  GIT_REPOSITORY https://github.com/masonlet/starlet-graphics.git 
+  GIT_REPOSITORY https://github.com/starlet-libs/graphics.git
   GIT_TAG main
 )
 FetchContent_MakeAvailable(starlet_graphics)


### PR DESCRIPTION
Updates LICENSE copyright and README repo URLs from starlet-engine org to starlet-libs.